### PR TITLE
Add link to compressed texture data and converter

### DIFF
--- a/Graphics/3D/Paletted_Cube/source/main.cpp
+++ b/Graphics/3D/Paletted_Cube/source/main.cpp
@@ -22,8 +22,7 @@ static const char* test_names[] = {
 	"4x4 compressed (GL_COMPRESSED)"
 };
 
-// I wish I could remember where I got this compressed texture from, but I'm sure that someone
-// who sees it might know where it comes from.
+// Texture obtained from https://github.com/kusma/nds_texcompress
 #include "texture10_COMP_tex_bin.h"
 #include "texture10_COMP_texExt_bin.h"
 #include "texture10_COMP_pal_bin.h"


### PR DESCRIPTION
The 3D example that uses a compressed texture didn't say where the
sample texture came from or how to convert an image to that format.

Fixes https://github.com/devkitPro/nds-examples/issues/1