### PR TITLE
Remove unnecessary call to videoSetModeSub

### DIFF
--- a/Graphics/Sprites/bitmap_sprites/source/main.cpp
+++ b/Graphics/Sprites/bitmap_sprites/source/main.cpp
@@ -25,8 +25,6 @@ int main(int argc, char** argv) {
       {0, SpriteSize_32x32, SpriteColorFormat_16Color, 0, 1, 20, 136}
    };
 
-   videoSetModeSub(MODE_0_2D);
-
    consoleDemoInit();
    
    //initialize the sub sprite engine with 1D mapping 128 byte boundary


### PR DESCRIPTION
consoleDemoInit enables MODE_0_2D on the sub display, so the call to videoSetModeSub isn't necessary.